### PR TITLE
regex support for line-terminating `mel`s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# vim swapfiles
+*.swp

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ rtm.on('message', (event) => {
         }
         
         const message = event;
-        const listen = /mel[^\w]/;
+        const listen = /mel\W|mel$/;
         const text = (message.text).toLowerCase();
         const response = responses[Math.floor(Math.random() * responses.length)];
        


### PR DESCRIPTION
fixes the bug where `hi mel!` would match but `hi mel` would not